### PR TITLE
feat(criteria-to-firestore): +criteria to firestore converter

### DIFF
--- a/.changeset/khaki-cycles-itch.md
+++ b/.changeset/khaki-cycles-itch.md
@@ -1,0 +1,5 @@
+---
+"@codelytv/criteria-to-firestore": major
+---
+
+- criteria to firestore

--- a/packages/criteria-to-firestore/README.md
+++ b/packages/criteria-to-firestore/README.md
@@ -1,0 +1,23 @@
+<p align="center">
+  <a href="https://codely.com">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://codely.com/logo/codely_logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://codely.com/logo/codely_logo-light.svg">
+      <img alt="Codely logo" src="https://codely.com/logo/codely_logo.svg">
+    </picture>
+  </a>
+</p>
+
+<h1 align="center">
+  🎼 Criteria to Firestore converter
+</h1>
+
+<p align="center">
+    <a href="https://github.com/CodelyTV"><img src="https://img.shields.io/badge/Codely-OS-green.svg?style=flat-square" alt="codely.com"/></a>
+</p>
+
+## 📥 Installation
+
+```sh
+npm i @codelytv/criteria-to-firestore
+```

--- a/packages/criteria-to-firestore/package.json
+++ b/packages/criteria-to-firestore/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@codelytv/criteria-to-firestore",
+	"version": "1.0.0",
+	"description": "",
+	"keywords": [],
+	"author": "Codely (https://codely.com)",
+	"license": "MIT",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"test": "node --import tsx --test test/*.test.ts",
+		"build": "tsc --build --verbose tsconfig.json"
+	},
+	"dependencies": {
+		"@codelytv/criteria": "workspace:^",
+		"@firebase/firestore": "^4.7.3"
+	},
+	"devDependencies": {
+		"@codelytv/criteria-test-mother": "workspace:^"
+	}
+}

--- a/packages/criteria-to-firestore/src/CriteriaToFirestore.ts
+++ b/packages/criteria-to-firestore/src/CriteriaToFirestore.ts
@@ -1,0 +1,67 @@
+import { Criteria, Filter, OrderTypes } from "@codelytv/criteria";
+import { limit, orderBy, QueryConstraint, startAfter, where } from "@firebase/firestore";
+
+type CriteriaMapper = Record<string, (v: string) => string | number>;
+
+export class CriteriaToFirestoreConverter {
+	convert(criteria: Criteria, mapper: CriteriaMapper = {}): QueryConstraint[] {
+		const constraints: QueryConstraint[] = [];
+		if (criteria.hasFilters()) {
+			criteria.filters.value.forEach((filter) => {
+				const constraint = this.getFilterFromCriteria(filter, mapper);
+				if (constraint) {
+					constraints.push(constraint);
+				}
+			});
+		}
+		if (criteria.hasOrder() && !criteria.order.isNone()) {
+			constraints.push(this.getOrderFromCriteria(criteria));
+		}
+		if (criteria.pageSize !== null) {
+			constraints.push(limit(criteria.pageSize));
+		}
+		if (criteria.pageNumber !== null && criteria.pageSize !== null) {
+			constraints.push(startAfter(criteria.pageSize * (criteria.pageNumber - 1)));
+		}
+
+		return constraints;
+	}
+
+	private getOrderFromCriteria(criteria: Criteria) {
+		const by = criteria.order.orderBy.value;
+		const orderType = criteria.order.orderType.value === OrderTypes.DESC ? "desc" : "asc";
+
+		return orderBy(by, orderType);
+	}
+
+	private getFilterFromCriteria(filter: Filter, mapper: CriteriaMapper) {
+		const field = filter.field.value;
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		const value = mapper[field] ? mapper[field](filter.value.value) : filter.value.value;
+
+		if (filter.operator.isContains()) {
+			return where(field, "in", value);
+		}
+		if (filter.operator.isNotContains()) {
+			return where(field, "not-in", value);
+		}
+		if (filter.operator.value.valueOf() === "=") {
+			return where(field, "==", value);
+		}
+		if (filter.operator.isNotEquals()) {
+			return where(field, "!=", value);
+		}
+		if (filter.operator.isGreaterThan()) {
+			return where(field, ">", value);
+		}
+		if (filter.operator.isGreaterThanOrEqual()) {
+			return where(field, ">=", value);
+		}
+		if (filter.operator.isLowerThan()) {
+			return where(field, "<", value);
+		}
+		if (filter.operator.isLowerThanOrEqual()) {
+			return where(field, "<=", value);
+		}
+	}
+}

--- a/packages/criteria-to-firestore/src/index.ts
+++ b/packages/criteria-to-firestore/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./CriteriaToFirestore";

--- a/packages/criteria-to-firestore/test/CriteriaToElasticsearchConverter.test.ts
+++ b/packages/criteria-to-firestore/test/CriteriaToElasticsearchConverter.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+import { CriteriaMother } from "@codelytv/criteria-test-mother";
+import { limit, orderBy, startAfter, where } from "@firebase/firestore";
+
+import { CriteriaToFirestoreConverter } from "../src";
+
+describe("CriteriaToFirestoreConverter should", () => {
+	const converter = new CriteriaToFirestoreConverter();
+
+	it("Generate simple query with an empty criteria", () => {
+		const actualQuery = converter.convert(CriteriaMother.empty());
+
+		assert.deepEqual(actualQuery, []);
+	});
+
+	it("Generate query with order", () => {
+		const actualQuery = converter.convert(CriteriaMother.emptySorted("id", "DESC"));
+
+		assert.deepEqual(actualQuery, [orderBy("id", "desc")]);
+	});
+
+	it("Generate query with one filter", () => {
+		const actualQuery = converter.convert(CriteriaMother.withOneFilter("name", "EQUAL", "Javier"));
+
+		assert.deepEqual(actualQuery, [where("name", "==", "Javier")]);
+	});
+
+	it("Generate query with one filter sorted", () => {
+		const actualQuery = converter.convert(
+			CriteriaMother.withOneFilterSorted("name", "EQUAL", "Javier", "id", "DESC"),
+		);
+
+		assert.deepEqual(actualQuery, [where("name", "==", "Javier"), orderBy("id", "desc")]);
+	});
+
+	it("Generate query with multiples filters", () => {
+		const actualQuery = converter.convert(
+			CriteriaMother.create({
+				filters: [
+					{
+						field: "name",
+						operator: "EQUAL",
+						value: "Javier",
+					},
+					{
+						field: "email",
+						operator: "EQUAL",
+						value: "javier@terra.es",
+					},
+				],
+				orderBy: null,
+				orderType: null,
+				pageSize: null,
+				pageNumber: null,
+			}),
+		);
+
+		assert.deepEqual(actualQuery, [
+			where("name", "==", "Javier"),
+			where("email", "==", "javier@terra.es"),
+		]);
+	});
+
+	it("Generate query with multiples filters and sort", () => {
+		const actualQuery = converter.convert(
+			CriteriaMother.create({
+				filters: [
+					{
+						field: "name",
+						operator: "EQUAL",
+						value: "Javier",
+					},
+					{
+						field: "email",
+						operator: "EQUAL",
+						value: "javier@terra.es",
+					},
+				],
+				orderBy: "id",
+				orderType: "DESC",
+				pageSize: null,
+				pageNumber: null,
+			}),
+		);
+
+		assert.deepEqual(actualQuery, [
+			where("name", "==", "Javier"),
+			where("email", "==", "javier@terra.es"),
+			orderBy("id", "desc"),
+		]);
+	});
+
+	it("Generate query with one contains filter", () => {
+		const actualQuery = converter.convert(
+			CriteriaMother.withOneFilter("name", "CONTAINS", "Javier"),
+		);
+
+		assert.deepEqual(actualQuery, [where("name", "in", "Javier")]);
+	});
+
+	it("Generate query with one greater filter and value converter", () => {
+		const actualQuery = converter.convert(
+			CriteriaMother.withOneFilter("age", "GREATER_THAN", "20"),
+			{ age: (v) => parseInt(v, 10) },
+		);
+
+		assert.deepEqual(actualQuery, [where("age", ">", 20)]);
+	});
+
+	it("Generate query with one not contains filter", () => {
+		const actualQuery = converter.convert(
+			CriteriaMother.withOneFilter("name", "NOT_CONTAINS", "Javier"),
+		);
+
+		assert.deepEqual(actualQuery, [where("name", "not-in", "Javier")]);
+	});
+
+	it("Generate simple query paginated", () => {
+		const pageSize = 10;
+		const pageNumber = 3;
+		const expectedSkip = pageSize * (pageNumber - 1);
+		const actualQuery = converter.convert(CriteriaMother.emptyPaginated(pageSize, pageNumber));
+
+		assert.deepEqual(actualQuery, [limit(pageSize), startAfter(expectedSkip)]);
+	});
+});

--- a/packages/criteria-to-firestore/tsconfig.json
+++ b/packages/criteria-to-firestore/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist"
+	},
+	"include": ["src/**/*"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,19 @@ importers:
         specifier: workspace:^
         version: link:../criteria-test-mother
 
+  packages/criteria-to-firestore:
+    dependencies:
+      '@codelytv/criteria':
+        specifier: workspace:^
+        version: link:../criteria
+      '@firebase/firestore':
+        specifier: ^4.7.3
+        version: 4.7.3(@firebase/app@0.10.13)
+    devDependencies:
+      '@codelytv/criteria-test-mother':
+        specifier: workspace:^
+        version: link:../criteria-test-mother
+
   packages/criteria-to-mysql:
     dependencies:
       '@codelytv/criteria':
@@ -404,6 +417,36 @@ packages:
     resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
 
+  '@firebase/app@0.10.13':
+    resolution: {integrity: sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==}
+
+  '@firebase/component@0.6.9':
+    resolution: {integrity: sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==}
+
+  '@firebase/firestore@4.7.3':
+    resolution: {integrity: sha512-NwVU+JPZ/3bhvNSJMCSzfcBZZg8SUGyzZ2T0EW3/bkUeefCyzMISSt/TTIfEHc8cdyXGlMqfGe3/62u9s74UEg==}
+    engines: {node: '>=10.10.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/logger@0.4.2':
+    resolution: {integrity: sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==}
+
+  '@firebase/util@1.10.0':
+    resolution: {integrity: sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==}
+
+  '@firebase/webchannel-wrapper@1.0.1':
+    resolution: {integrity: sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==}
+
+  '@grpc/grpc-js@1.9.15':
+    resolution: {integrity: sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+
+  '@grpc/proto-loader@0.7.13':
+    resolution: {integrity: sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -516,6 +559,36 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -1223,6 +1296,9 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
@@ -1418,11 +1494,17 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  long@5.2.3:
+    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1650,6 +1732,10 @@ packages:
     resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
     engines: {node: '>=14'}
     hasBin: true
+
+  protobufjs@7.4.0:
+    resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
+    engines: {node: '>=12.0.0'}
 
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -1981,6 +2067,10 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici@6.19.7:
+    resolution: {integrity: sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==}
+    engines: {node: '>=18.17'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -2475,6 +2565,53 @@ snapshots:
 
   '@faker-js/faker@8.4.1': {}
 
+  '@firebase/app@0.10.13':
+    dependencies:
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      idb: 7.1.1
+      tslib: 2.6.3
+
+  '@firebase/component@0.6.9':
+    dependencies:
+      '@firebase/util': 1.10.0
+      tslib: 2.6.3
+
+  '@firebase/firestore@4.7.3(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      '@firebase/webchannel-wrapper': 1.0.1
+      '@grpc/grpc-js': 1.9.15
+      '@grpc/proto-loader': 0.7.13
+      tslib: 2.6.3
+      undici: 6.19.7
+
+  '@firebase/logger@0.4.2':
+    dependencies:
+      tslib: 2.6.3
+
+  '@firebase/util@1.10.0':
+    dependencies:
+      tslib: 2.6.3
+
+  '@firebase/webchannel-wrapper@1.0.1': {}
+
+  '@grpc/grpc-js@1.9.15':
+    dependencies:
+      '@grpc/proto-loader': 0.7.13
+      '@types/node': 20.14.2
+
+  '@grpc/proto-loader@0.7.13':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.2.3
+      protobufjs: 7.4.0
+      yargs: 17.7.2
+
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2566,6 +2703,29 @@ snapshots:
       fastq: 1.17.1
 
   '@pkgr/core@0.1.1': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -3432,6 +3592,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb@7.1.1: {}
+
   ignore@5.3.1: {}
 
   import-fresh@3.3.0:
@@ -3602,9 +3764,13 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.startcase@4.4.0: {}
+
+  long@5.2.3: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -3832,6 +3998,21 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.3.2: {}
+
+  protobufjs@7.4.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.14.2
+      long: 5.2.3
 
   pseudomap@1.0.2: {}
 
@@ -4174,6 +4355,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@5.26.5: {}
+
+  undici@6.19.7: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
Se creó el paquete `criteria-to-firestore` para convertir la clase `Criteria` en una consulta de Firestore, posibilitando realizar consultas basadas en criterios definidos en aplicaciones de Firebase.

## Ejemplo de uso
```ts
const criteria = Criteria.fromPrimitives(
	[{ field: "age", operator: "GREATER_THAN", value: "20" }],
	"id",
	"desc",
	10,
	3,
);
const converter = new CriteriaToFirestoreConverter()
const constraints = converter.convert(criteria, { age: (v) => parseInt(v, 10) }) // [ ...QueryConstraint() ]

const q = query(collection(db, "users"), ...constraints)
const docs = await getDocs(q)
```